### PR TITLE
Add Metrics from 1_Div/2_Gro/3_Risk to List of Metrics

### DIFF
--- a/1_Diversity-Inclusion.md
+++ b/1_Diversity-Inclusion.md
@@ -2,16 +2,16 @@
 
 Activity Metric | Description
 --- | ---
-New Contributors* vs Maintainers** | Ratio of new contributors to maintainers over time
-Contributor Demographics | Gender, age, location, education, and skills over time
-Leadership Demographics | Demographics of project's leadership (e.g. Board, Technical Steering Committee, Maintainers, etc.) over time
-New Contributor Organizations | New organizations contributing to the project over time
-Number of Contributing Organizations | Number of organizations participating in the project over time
-New Contributions | Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time
-Accepted Code Contributions | Percentage of new contributor code versus total code over time
-Path to Maintainership | Path to maintainership published
-Maintainer Promotion | Last time a maintainer was added
-Change in Maintainer Number | Number of maintainers added/removed over time
+New Contributors* vs Maintainers** | Ratio of new contributors to maintainers over time.
+Contributor Demographics | Gender, age, location, education, and skills over time.
+Leadership Demographics | Demographics of project's leadership (e.g. Board, Technical Steering Committee, Maintainers, etc.) over time.
+New Contributor Organizations | New organizations contributing to the project over time.
+Number of Contributing Organizations | Number of organizations participating in the project over time.
+New Contributions | Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time.
+Accepted Code Contributions | Percentage of new contributor code versus total code over time.
+Path to Maintainership | Path to maintainership published.
+Maintainer Promotion | Last time a maintainer was added.
+Change in Maintainer Number | Number of maintainers added/removed over time.
 
 *Contributor = Anyone who provides a patch, pull request, wiki change, or other contribution.
 **Maintainer = Contributor who has commit rights to the main branch and can merge contributions from others.

--- a/2_Growth-Maturity-Decline.md
+++ b/2_Growth-Maturity-Decline.md
@@ -1,38 +1,38 @@
 # Metric: Growth-Maturity-Decline
 
 ## Issue Resolution
- Activity Metric | Description
- --- | ---
- Open issues | Total number of open issues.
- Closed issues | Total number of closed issues.
- Resolution efficiency | Number of closed issues / number of abandoned issues.
- Average time of open issues | The average amount of time open issues have remained open.
- Percentile distribution of open issue time | Proportional frequency of open issue time duration.
- Average issue resolution time | The average amount of time it takes for issues to be closed.
- Percentile distribution of issue resolution time | Proportional frequency of closed issue time duration.
- Average time of first response to issue | The average amount of time it takes for the first response to an issue.
- Percentile distribution of first response time | The proportional frequency of time it takes for the first response to an issue.
+Activity Metric | Description
+--- | ---
+Open Issues | Total number of open issues.
+Closed Issues | Total number of closed issues.
+Resolution Efficiency | Number of closed issues / number of abandoned issues.
+Average Time of Open Issues | The average amount of time open issues have remained open.
+Percentile Distribution of Open Issue Time | Proportional frequency of open issue time duration.
+Average Issue Resolution Time | The average amount of time it takes for issues to be closed.
+Percentile Distribution of Issue Resolution Time | Proportional frequency of closed issue time duration.
+Average Time of First Response to Issue | The average amount of time it takes for the first response to an issue.
+Percentile Distribution of First Response Time | The proportional frequency of time it takes for the first response to an issue.
 
 ## Code Development
- Activity Metric | Description
- --- | ---
- Number of commits | Total number of commits.
- Number of lines changed | Total number of lines of code that have been changed.
- Number of reviews | Total number of code reviews
- Average time to merge code | The average amount of time difference between code author and commit dates.
- Percentile distribution of time to merge code |Proportional frequency of code merge to upstream time duration.
- Review efficiency | Number of merged patches / number of abandoned patches over a set period of time.
- Average time of first maintainer response to code merge request | The average amount of time it takes for a maintainer to make the first response to a code merge request.
- Percentile distribution of first maintainer response to code merge request | The proportional frequency of time it takes for a maintainer to make the first response to a code merge request.
+Activity Metric | Description
+--- | ---
+Number of Commits | Total number of commits.
+Number of Lines Changed | Total number of lines of code that have been changed.
+Number of Reviews | Total number of code reviews.
+Average time to merge code | The average amount of time difference between code author and commit dates.
+Percentile Distribution of Time to Merge Code | Proportional frequency of code merge to upstream time duration.
+Review Efficiency | Number of merged patches / number of abandoned patches over a set period of time.
+Average Time of First Maintainer Response to Code Merge Request | The average amount of time it takes for a maintainer to make the first response to a code merge request.
+Percentile Distribution of First Maintainer Response to Code Merge Request | The proportional frequency of time it takes for a maintainer to make the first response to a code merge request.
 
 ## Community Growth
- Activity Metric | Description
- --- | ---
- Total contributors | The total number of contributors over time on any platform.
- Total new contributors | The total number of new contributors over time on any platform.
- Total contributing organizations | The total number of organizations contributing over time
- Total new contributing organizations | The total number of new organizations contributing over time.
- Total (sub)projects | The total number of (sub)projects over time.
+Activity Metric | Description
+--- | ---
+Total Contributors | The total number of contributors over time on any platform.
+Total New Contributors | The total number of new contributors over time on any platform.
+Total Contributing Organizations | The total number of organizations contributing over time.
+Total New Contributing Organizations | The total number of new organizations contributing over time.
+Total (Sub-)Projects | The total number of (sub)projects over time.
 
 **Disclaimer:**
 The activity metrics listed are not meant to represent a fully comprehensive list. It is fully expected that this list will evolve as people have insights and thoughts about the activity metrics that comprise Growth-Maturity-Decline.

--- a/3_Risk.md
+++ b/3_Risk.md
@@ -3,26 +3,26 @@
 ## Human Factors
 Activity Metric | Description
 --- | ---
-Contributor Importance | Percentage of commits by individual contributors from identified organizations over time
-Qualified Committers | Contributions over time and what components they commit to over time
-User Dependency | Number of users who are aware that they depend on the software over time
-Paid developers | Number of paid developers in community over time
+Contributor Importance | Percentage of commits by individual contributors from identified organizations over time.
+Qualified Committers | Contributions over time and what components they commit to over time.
+User Dependency | Number of users who are aware that they depend on the software over time.
+Paid Developers | Number of paid developers in community over time.
 
 ## Copyright and License Factors
  Activity Metric | Description
  --- | ---
-Copyright Declaration | The degree to which the project properly declares copyright ownership, including the copyright symbol or 'copyright' word, the year of the creation, the name of the author, and a rights statement
-Package License Declaration | A list of license declarations on the software package
-File License Declarations | A list of license declarations on the software package files
-License Identification Methods | A list of methods or tools used for identifying licenses in files
+Copyright Declaration | The degree to which the project properly declares copyright ownership, including the copyright symbol or 'copyright' word, the year of the creation, the name of the author, and a rights statement.
+Package License Declaration | A list of license declarations on the software package.
+File License Declarations | A list of license declarations on the software package files.
+License Identification Methods | A list of methods or tools used for identifying licenses in files.
 
 
 ## Vulnerability Factors
  Activity Metric | Description
  --- | ---
-Published CPE | The number of published [Common Platform Enumerations (CPEs)](https://nvd.nist.gov/products/cpe) for the project (i.e., a project can contain many packages)
-Disclosed Vulnerabilities | The number of disclosed package vulnerabilities
-Vulnerabilities in Media | The number of published press about package related vulnerabilities
+Published CPE | The number of published [Common Platform Enumerations (CPEs)](https://nvd.nist.gov/products/cpe) for the project (i.e., a project can contain many packages).
+Disclosed Vulnerabilities | The number of disclosed package vulnerabilities.
+Vulnerabilities in Media | The number of published press about package related vulnerabilities.
 
 **Disclaimer:**
 The activity metrics listed are not meant to represent a fully comprehensive list. It is fully expected that this list will evolve as people have insights and thoughts about the activity metrics that comprise Risk.

--- a/activity-metrics-list.md
+++ b/activity-metrics-list.md
@@ -5,6 +5,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 
 |Name|Description|
 |---|---|
+|Accepted Code Contributions|Percentage of new contributor code versus total code over time|
 |Age of Community|Time since repository/organization was registered; or time since first release. "Results showed that the age of the project played a marginally significant role in attracting active users, but not developers. We attribute this differential effect of age on users and developers to the fact that age may be seen as an indicator of application maturity by users, and hence taken as a positive signal, whereas it may convey more ambiguous signals to developers." (Chengalur-Smith et al., 2010, p.674) (Grewal, Lilien, & Mallapragada, 2006)|
 |All Licenses|List of licenses|
 |Apache Maturity Model| The [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html) provides guidelines for assessing the maturity of a project|
@@ -13,6 +14,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Bug Age|Age of known bugs in issue tracker. Use label for determining bugs?|
 |Bugs after Release|Number of bugs reported after a release|
 |Bus Factor|The number of developers it would need to lose to destroy its progress. Alternatively: Number of companies that would have to stop support.|
+|Change in Maintainer Number|Number of maintainers added/removed over time|
 |CII Best Practices Badge|The [CII Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/) provide maturity self-certification: passing, silver, and gold.|
 |Code Modularity|Modular code allows parallel development, which Linus Torvalds drove for Linux (OSLS Torvalds). (Baldwin & Clark, 2006)|
 |Commercial Offerings|Availability of commercial products or services based on the project|
@@ -23,6 +25,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 |[Contribution Diversity](activity-metrics/contribution-diversity.md)|Ratio of code committed by contributors other than original project initiator. Contributions going up beyond the core team|
 |Contributor Activity|Activity level of individual contributors|
 |[Contributor Breadth](activity-metrics/contributor-breadth.md)|Ratio of non-core committers (drive-by committers). Can indicate openess to outsiders|
+|Contributor Demographics | Gender, age, location, education, and skills over time|
 |[Contributor Diversity](activity-metrics/contributor-diversity.md)| Ratio of contributors from a single company over all contributors. Also described as: Maintainers from different companies. Diversity of contributor affiliation.|
 |Contributor Seniority|For each active contributor, time since first contribution. Experienced contributors can provide value to the community, since they carry with them (in part) the history of the project.|
 |[Contributors](activity-metrics/contributors.md)|Number of contributors|
@@ -40,14 +43,21 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Job Postings|Number of job postings that mention the project as a preferred or required skill|
 |Known Vulnerabilities|Number of reported vulnerabilities. Could be limited to issue-tracker or extended vulnerability databases (e.g. CVE)|
 |Language Bias|Bias against gender, ethnicity, ... in use of language (maybe use sentiment analysis)|
+|Leadership Demographics|Demographics of project's leadership (e.g. Board, Technical Steering Committee, Maintainers, etc.) over time|
 |License Conflicts|Project containing incompatible licenses|
 |License Count|Number of licenses|
 |License Coverage|Number of files with a file notice (copyright notice + license notice)|
 |License Declared|What license does the project declare|
+|Maintainer Promotion|Last time a maintainer was added|
+|New Contributions|Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time|
+|New Contributor Organizations|New organizations contributing to the project over time|
+|New Contributors* vs Maintainers**|Ratio of new contributors to maintainers over time|
 |Non-Source Contributions|Track contributions like running tests in test environment, writing blog posts, producing videos, giving talks, etc...|
 |Number of Active Users|Number of active users of the project|
+|Number of Contributing Organizations|Number of organizations participating in the project over time|
 |Onion Layers|Distance between onion model layers (users, contributors, committers, and steering committee). Rule of thumb: factor of 10x between layers. (OSLS'17 Node.js keynote)|
 |Path to Leadership|A communicated path from lurker to contributor to maintainer. (or. track members: time from user to maintainer/leader). If active contributors are not included in leadership decisions they might lose interest and leave. (Focus on least likely contributor)|
+|Path to Maintainership|Path to maintainership published|
 |Project Life Cycle|Community assigned label. Some communities have a project life cycle for example: proposal, incubaton, active, deprecated, end of life (Source: [Hyperledger](https://wiki.hyperledger.org/community/project-lifecycle)).|
 |[Pull Request Comments](activity-metrics/pull-request-comments.md)|Number of comments per pull request|
 |[Pull Request Discussion Diversity](activity-metrics/pull-request-discussion-diversity.md)|Number of different people discussing each pull request|

--- a/activity-metrics-list.md
+++ b/activity-metrics-list.md
@@ -11,11 +11,16 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Apache Maturity Model| The [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html) provides guidelines for assessing the maturity of a project|
 |Availability of Add-on Products|Availability of 3rd party plug-ins, modules, utilities, etc. that provide additional functionality for the project's software|
 |Blogposts|Number of blogposts that mention the project|
+|Average Time of First Maintainer Response to Code Merge Request|The average amount of time it takes for a maintainer to make the first response to a code merge request.|
+|Average Time of First Response to Issue|The average amount of time it takes for the first response to an issue.|
+|Average Time of Open Issues|The average amount of time open issues have remained open.|
+|Average Issue Resolution Time|The average amount of time it takes for issues to be closed.|
 |Bug Age|Age of known bugs in issue tracker. Use label for determining bugs?|
 |Bugs after Release|Number of bugs reported after a release|
 |Bus Factor|The number of developers it would need to lose to destroy its progress. Alternatively: Number of companies that would have to stop support.|
 |Change in Maintainer Number|Number of maintainers added/removed over time|
 |CII Best Practices Badge|The [CII Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/) provide maturity self-certification: passing, silver, and gold.|
+|Closed issues|Total number of closed issues.|
 |Code Modularity|Modular code allows parallel development, which Linus Torvalds drove for Linux (OSLS Torvalds). (Baldwin & Clark, 2006)|
 |Commercial Offerings|Availability of commercial products or services based on the project|
 |Commit Bias|Acceptance rate (and time to acceptance) differences per gender, ethnicity, and relevant diversity characteristics|
@@ -54,11 +59,19 @@ We list and describe activity metrics. For different situations, the metrics hav
 |New Contributors* vs Maintainers**|Ratio of new contributors to maintainers over time|
 |Non-Source Contributions|Track contributions like running tests in test environment, writing blog posts, producing videos, giving talks, etc...|
 |Number of Active Users|Number of active users of the project|
+|Number of Commits|Total number of commits.|
 |Number of Contributing Organizations|Number of organizations participating in the project over time|
+|Number of Reviews|Total number of code reviews.|
 |Onion Layers|Distance between onion model layers (users, contributors, committers, and steering committee). Rule of thumb: factor of 10x between layers. (OSLS'17 Node.js keynote)|
+|Open Issues|Total number of open issues.|
 |Path to Leadership|A communicated path from lurker to contributor to maintainer. (or. track members: time from user to maintainer/leader). If active contributors are not included in leadership decisions they might lose interest and leave. (Focus on least likely contributor)|
 |Path to Maintainership|Path to maintainership published|
 |Project Life Cycle|Community assigned label. Some communities have a project life cycle for example: proposal, incubaton, active, deprecated, end of life (Source: [Hyperledger](https://wiki.hyperledger.org/community/project-lifecycle)).|
+|Percentile Distribution of First Maintainer Response to Code Merge Request|The proportional frequency of time it takes for a maintainer to make the first response to a code merge request.|
+|Percentile Distribution of First Response Time|The proportional frequency of time it takes for the first response to an issue.|
+|Percentile Distribution of Issue Resolution Time|Proportional frequency of closed issue time duration.|
+|Percentile Distribution of Open Issue Time|Proportional frequency of open issue time duration.|
+|Percentile Distribution of Time to Merge Code|Proportional frequency of code merge to upstream time duration.|
 |[Pull Request Comments](activity-metrics/pull-request-comments.md)|Number of comments per pull request|
 |[Pull Request Discussion Diversity](activity-metrics/pull-request-discussion-diversity.md)|Number of different people discussing each pull request|
 |[Pull Request made/closed](activity-metrics/pull-requests-made-closed.md)|Pull requests made vs. pull requests closed [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap). Encompasses number of pull requests rejected|
@@ -67,9 +80,11 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Release Maturity|Ratio of major and minor releases|
 |Release Note Completeness|Number of functionality changes and bug fixes represented in release notes vs. release. Good for users, also shows diligence of community|
 |Release Velocity|Time between releases. Regular releases are a reliability metric|
-|[Reopened issues](activity-metrics/reopened-issues.md)|Rate of issues closed but discussion continues or issues that were closed and re-opened|
+|[Reopened Issues](activity-metrics/reopened-issues.md)|Rate of issues closed but discussion continues or issues that were closed and re-opened|
 |[Repository Size](activity-metrics/repository-size.md)|Overall size of the repository or number of commits|
 |Retrospectives|Existence of after release meetings. Collect lessons learned, improve processes, recognize contributors|
+|Resolution Efficiency|Number of closed issues / number of abandoned issues.|
+|Review Efficiency|Number of merged patches / number of abandoned patches over a set period of time.|
 |Rewards|Rewards, shout-outs, recognition, and mentions in pull-requests or change logs - might improve contribution levels|
 |Roadmap|Existence and quality of roadmap. Best practice as community engagement and scalability (might not be automatically computable)|
 |Role Definitions|Existence and quality of role definitions. Governance related. Relates to "Path to Leadership"|
@@ -79,6 +94,11 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Stars|Number of stars (GitHub)|
 |Test Coverage|Percentage of codebase covered by developer tests|
 |Time to Contributor|Time to becoming a contributor|
+|Total Contributing Organizations|The total number of organizations contributing over time.|
+|Total Contributors|The total number of contributors over time on any platform.|
+|Total New Contributing Organizations|The total number of new organizations contributing over time.|
+|Total New Contributors|The total number of new contributors over time on any platform.|
+|Total (Sub-)Projects|The total number of (sub)projects over time.|
 |[Transparency](activity-metrics/transparency.md)|Number of comments per issue. Discussion is occuring openly - could also indicate level of agreement|
 |Unity|Rivalry or unity of community (sentiment analysis)|
 |Update Age|Time since last update|

--- a/activity-metrics-list.md
+++ b/activity-metrics-list.md
@@ -32,12 +32,15 @@ We list and describe activity metrics. For different situations, the metrics hav
 |[Contributor Breadth](activity-metrics/contributor-breadth.md)|Ratio of non-core committers (drive-by committers). Can indicate openess to outsiders|
 |Contributor Demographics | Gender, age, location, education, and skills over time|
 |[Contributor Diversity](activity-metrics/contributor-diversity.md)| Ratio of contributors from a single company over all contributors. Also described as: Maintainers from different companies. Diversity of contributor affiliation.|
+|Contributor Importance|Percentage of commits by individual contributors from identified organizations over time.|
 |Contributor Seniority|For each active contributor, time since first contribution. Experienced contributors can provide value to the community, since they carry with them (in part) the history of the project.|
 |[Contributors](activity-metrics/contributors.md)|Number of contributors|
+|Copyright Declaration|The degree to which the project properly declares copyright ownership, including the copyright symbol or 'copyright' word, the year of the creation, the name of the author, and a rights statement.|
 |Decision Distribution|Central vs. distributed decision making. Governance model, scalability of community|
 |Dependency Depth|Number of projects included in code base + number of projects relying on focal project (recursive). Indicator about centrality in open source Dependency network|
 |Distribution of Work|How much recent activity is distributed?|
 |Downloads of Non-software Artifacts|Number of downloads of non-software artifacts (e.g. documentation, sample apps, test suites, etc.)|
+|File License Declarations|A list of license declarations on the software package files.|
 |[Forks](activity-metrics/forks.md)|Number of forks|
 |Gatherings|Number of face-to-face/in-person meetings per year. Resets contentious issues; Resolve tensions; Avoid longstanding grudges|
 |Installs|Number of software installations of the project|
@@ -53,6 +56,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 |License Count|Number of licenses|
 |License Coverage|Number of files with a file notice (copyright notice + license notice)|
 |License Declared|What license does the project declare|
+|License Identification Methods|A list of methods or tools used for identifying licenses in files.|
 |Maintainer Promotion|Last time a maintainer was added|
 |New Contributions|Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time|
 |New Contributor Organizations|New organizations contributing to the project over time|
@@ -64,6 +68,8 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Number of Reviews|Total number of code reviews.|
 |Onion Layers|Distance between onion model layers (users, contributors, committers, and steering committee). Rule of thumb: factor of 10x between layers. (OSLS'17 Node.js keynote)|
 |Open Issues|Total number of open issues.|
+|Package License Declaration|A list of license declarations on the software package.|
+|Paid Developers|Number of paid developers in community over time.|
 |Path to Leadership|A communicated path from lurker to contributor to maintainer. (or. track members: time from user to maintainer/leader). If active contributors are not included in leadership decisions they might lose interest and leave. (Focus on least likely contributor)|
 |Path to Maintainership|Path to maintainership published|
 |Project Life Cycle|Community assigned label. Some communities have a project life cycle for example: proposal, incubaton, active, deprecated, end of life (Source: [Hyperledger](https://wiki.hyperledger.org/community/project-lifecycle)).|
@@ -76,6 +82,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 |[Pull Request Discussion Diversity](activity-metrics/pull-request-discussion-diversity.md)|Number of different people discussing each pull request|
 |[Pull Request made/closed](activity-metrics/pull-requests-made-closed.md)|Pull requests made vs. pull requests closed [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap). Encompasses number of pull requests rejected|
 |[Pull Requests Open](activity-metrics/pull-requests-open.md)|Number of open pull requests. Perhaps more telling than total pull requests|
+|Qualified Committers|Contributions over time and what components they commit to over time.|
 |Relative Activity| Sum up the activities (GH issues+comments, GH pull requests+comments and GH commits) for the project members and for the non-project members, then  create a ratio of the two. Compare the activity between committers-as-a-group and contributors-as-a-group. It easily shows when a project is not yet popular, or when a project is not paying attention to its users. I also feel that a balance between the two groups is essential; ie) a project with a lot more contributor than committer activity is one that is failing to recruit committers quickly enough|
 |Release Maturity|Ratio of major and minor releases|
 |Release Note Completeness|Number of functionality changes and bug fixes represented in release notes vs. release. Good for users, also shows diligence of community|
@@ -105,6 +112,7 @@ We list and describe activity metrics. For different situations, the metrics hav
 |Update Rate|Number of updates over period x|
 |Update Regularity|How consistently and frequently are updates provided|
 |Use of Acronym|Frequency of acronyms used. Specialized language can be a barrier for new contributors|
+|User Dependency|Number of users who are aware that they depend on the software over time.|
 |User Groups|Number of user groups that perform a variety of crucial marketing, service support, and business-development functions at the grassroots level\\ (Bagozzi & Dholakia, 2006)|
 |[Watchers](activity-metrics/watchers.md)|Number of watchers (GitHub)|
 |YouTube Videos|Number of Youtube videos that mention or specifically deal with the project (e.g. tutorials)

--- a/activity-metrics-list.md
+++ b/activity-metrics-list.md
@@ -5,118 +5,118 @@ We list and describe activity metrics. For different situations, the metrics hav
 
 |Name|Description|
 |---|---|
-|Accepted Code Contributions|Percentage of new contributor code versus total code over time|
-|Age of Community|Time since repository/organization was registered; or time since first release. "Results showed that the age of the project played a marginally significant role in attracting active users, but not developers. We attribute this differential effect of age on users and developers to the fact that age may be seen as an indicator of application maturity by users, and hence taken as a positive signal, whereas it may convey more ambiguous signals to developers." (Chengalur-Smith et al., 2010, p.674) (Grewal, Lilien, & Mallapragada, 2006)|
-|All Licenses|List of licenses|
-|Apache Maturity Model| The [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html) provides guidelines for assessing the maturity of a project|
-|Availability of Add-on Products|Availability of 3rd party plug-ins, modules, utilities, etc. that provide additional functionality for the project's software|
-|Blogposts|Number of blogposts that mention the project|
+|Accepted Code Contributions|Percentage of new contributor code versus total code over time.|
+|Age of Community|Time since repository/organization was registered; or time since first release. "Results showed that the age of the project played a marginally significant role in attracting active users, but not developers. We attribute this differential effect of age on users and developers to the fact that age may be seen as an indicator of application maturity by users, and hence taken as a positive signal, whereas it may convey more ambiguous signals to developers." (Chengalur-Smith et al., 2010, p.674) (Grewal, Lilien, & Mallapragada, 2006).|
+|All Licenses|List of licenses.|
+|Apache Maturity Model| The [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html) provides guidelines for assessing the maturity of a project.|
+|Availability of Add-on Products|Availability of 3rd party plug-ins, modules, utilities, etc. that provide additional functionality for the project's software.|
+|Blogposts|Number of blogposts that mention the project.|
 |Average Time of First Maintainer Response to Code Merge Request|The average amount of time it takes for a maintainer to make the first response to a code merge request.|
 |Average Time of First Response to Issue|The average amount of time it takes for the first response to an issue.|
 |Average Time of Open Issues|The average amount of time open issues have remained open.|
 |Average Issue Resolution Time|The average amount of time it takes for issues to be closed.|
 |Bug Age|Age of known bugs in issue tracker. Use label for determining bugs?|
-|Bugs after Release|Number of bugs reported after a release|
+|Bugs after Release|Number of bugs reported after a release.|
 |Bus Factor|The number of developers it would need to lose to destroy its progress. Alternatively: Number of companies that would have to stop support.|
-|Change in Maintainer Number|Number of maintainers added/removed over time|
+|Change in Maintainer Number|Number of maintainers added/removed over time.|
 |CII Best Practices Badge|The [CII Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/) provide maturity self-certification: passing, silver, and gold.|
 |Closed issues|Total number of closed issues.|
-|Code Modularity|Modular code allows parallel development, which Linus Torvalds drove for Linux (OSLS Torvalds). (Baldwin & Clark, 2006)|
-|Commercial Offerings|Availability of commercial products or services based on the project|
-|Commit Bias|Acceptance rate (and time to acceptance) differences per gender, ethnicity, and relevant diversity characteristics|
-|[Community Activity](activity-metrics/community-activity.md)|Contribution Frequency. Contribution = commit, issue, comment, etc.)|
-|[Contribution Acceptance](activity-metrics/contribution-acceptance.md)|Ratio of contributions accepted vs. closed without acceptance |
-|Contribution Age|Time since last contribution. Contribution = commit, issue, comment, etc.)|
-|[Contribution Diversity](activity-metrics/contribution-diversity.md)|Ratio of code committed by contributors other than original project initiator. Contributions going up beyond the core team|
-|Contributor Activity|Activity level of individual contributors|
-|[Contributor Breadth](activity-metrics/contributor-breadth.md)|Ratio of non-core committers (drive-by committers). Can indicate openess to outsiders|
-|Contributor Demographics | Gender, age, location, education, and skills over time|
+|Code Modularity|Modular code allows parallel development, which Linus Torvalds drove for Linux (OSLS Torvalds). (Baldwin & Clark, 2006).|
+|Commercial Offerings|Availability of commercial products or services based on the project.|
+|Commit Bias|Acceptance rate (and time to acceptance) differences per gender, ethnicity, and relevant diversity characteristics.|
+|[Community Activity](activity-metrics/community-activity.md)|Contribution Frequency. Contribution = commit, issue, comment, etc.).|
+|[Contribution Acceptance](activity-metrics/contribution-acceptance.md)|Ratio of contributions accepted vs. closed without acceptance.|
+|Contribution Age|Time since last contribution. Contribution = commit, issue, comment, etc.).|
+|[Contribution Diversity](activity-metrics/contribution-diversity.md)|Ratio of code committed by contributors other than original project initiator. Contributions going up beyond the core team.|
+|Contributor Activity|Activity level of individual contributors.|
+|[Contributor Breadth](activity-metrics/contributor-breadth.md)|Ratio of non-core committers (drive-by committers). Can indicate openness to outsiders.|
+|Contributor Demographics | Gender, age, location, education, and skills over time.|
 |[Contributor Diversity](activity-metrics/contributor-diversity.md)| Ratio of contributors from a single company over all contributors. Also described as: Maintainers from different companies. Diversity of contributor affiliation.|
 |Contributor Importance|Percentage of commits by individual contributors from identified organizations over time.|
 |Contributor Seniority|For each active contributor, time since first contribution. Experienced contributors can provide value to the community, since they carry with them (in part) the history of the project.|
-|[Contributors](activity-metrics/contributors.md)|Number of contributors|
+|[Contributors](activity-metrics/contributors.md)|Number of contributors.|
 |Copyright Declaration|The degree to which the project properly declares copyright ownership, including the copyright symbol or 'copyright' word, the year of the creation, the name of the author, and a rights statement.|
-|Decision Distribution|Central vs. distributed decision making. Governance model, scalability of community|
-|Dependency Depth|Number of projects included in code base + number of projects relying on focal project (recursive). Indicator about centrality in open source Dependency network|
+|Decision Distribution|Central vs. distributed decision making. Governance model, scalability of community.|
+|Dependency Depth|Number of projects included in code base + number of projects relying on focal project (recursive). Indicator about centrality in open source Dependency network.|
 |Distribution of Work|How much recent activity is distributed?|
-|Downloads of Non-software Artifacts|Number of downloads of non-software artifacts (e.g. documentation, sample apps, test suites, etc.)|
+|Downloads of Non-software Artifacts|Number of downloads of non-software artifacts (e.g. documentation, sample apps, test suites, etc.).|
 |File License Declarations|A list of license declarations on the software package files.|
-|[Forks](activity-metrics/forks.md)|Number of forks|
-|Gatherings|Number of face-to-face/in-person meetings per year. Resets contentious issues; Resolve tensions; Avoid longstanding grudges|
-|Installs|Number of software installations of the project|
-|[Issue Comments](activity-metrics/issue-comments.md)|Number of comments per issue|
+|[Forks](activity-metrics/forks.md)|Number of forks.|
+|Gatherings|Number of face-to-face/in-person meetings per year. Resets contentious issues; Resolve tensions; Avoid longstanding grudges.|
+|Installs|Number of software installations of the project.|
+|[Issue Comments](activity-metrics/issue-comments.md)|Number of comments per issue.|
 |[Issue Response Rate](activity-metrics/issue-response-rate.md)| Time between a new issue is opened and a maintainer responds. Also called: bug response rate. The maintainer is believed to not "pile on" but try to solve an issue.|
-|[Issues Open](activity-metrics/issues-open.md)|Number of open issues|
-|[Issues submitted/closed](activity-metrics/issues-submitted-closed.md)|Issues submitted vs. issues closed. [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap)|
-|Job Postings|Number of job postings that mention the project as a preferred or required skill|
-|Known Vulnerabilities|Number of reported vulnerabilities. Could be limited to issue-tracker or extended vulnerability databases (e.g. CVE)|
-|Language Bias|Bias against gender, ethnicity, ... in use of language (maybe use sentiment analysis)|
-|Leadership Demographics|Demographics of project's leadership (e.g. Board, Technical Steering Committee, Maintainers, etc.) over time|
-|License Conflicts|Project containing incompatible licenses|
-|License Count|Number of licenses|
-|License Coverage|Number of files with a file notice (copyright notice + license notice)|
-|License Declared|What license does the project declare|
+|[Issues Open](activity-metrics/issues-open.md)|Number of open issues.|
+|[Issues submitted/closed](activity-metrics/issues-submitted-closed.md)|Issues submitted vs. issues closed. [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap).|
+|Job Postings|Number of job postings that mention the project as a preferred or required skill.|
+|Known Vulnerabilities|Number of reported vulnerabilities. Could be limited to issue-tracker or extended vulnerability databases (e.g. CVE).|
+|Language Bias|Bias against gender, ethnicity, ... in use of language (maybe use sentiment analysis).|
+|Leadership Demographics|Demographics of project's leadership (e.g. Board, Technical Steering Committee, Maintainers, etc.) over time.|
+|License Conflicts|Project containing incompatible licenses.|
+|License Count|Number of licenses.|
+|License Coverage|Number of files with a file notice (copyright notice + license notice).|
+|License Declared|What license does the project declare.|
 |License Identification Methods|A list of methods or tools used for identifying licenses in files.|
-|Maintainer Promotion|Last time a maintainer was added|
-|New Contributions|Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time|
-|New Contributor Organizations|New organizations contributing to the project over time|
-|New Contributors* vs Maintainers**|Ratio of new contributors to maintainers over time|
+|Maintainer Promotion|Last time a maintainer was added.|
+|New Contributions|Percentage of contributions (patches, pull requests, etc.) from new contributors vs all accepted contributions over time.|
+|New Contributor Organizations|New organizations contributing to the project over time.|
+|New Contributors* vs Maintainers**|Ratio of new contributors to maintainers over time.|
 |Non-Source Contributions|Track contributions like running tests in test environment, writing blog posts, producing videos, giving talks, etc...|
-|Number of Active Users|Number of active users of the project|
+|Number of Active Users|Number of active users of the project.|
 |Number of Commits|Total number of commits.|
-|Number of Contributing Organizations|Number of organizations participating in the project over time|
+|Number of Contributing Organizations|Number of organizations participating in the project over time.|
 |Number of Reviews|Total number of code reviews.|
-|Onion Layers|Distance between onion model layers (users, contributors, committers, and steering committee). Rule of thumb: factor of 10x between layers. (OSLS'17 Node.js keynote)|
+|Onion Layers|Distance between onion model layers (users, contributors, committers, and steering committee). Rule of thumb: factor of 10x between layers. (OSLS'17 Node.js keynote).|
 |Open Issues|Total number of open issues.|
 |Package License Declaration|A list of license declarations on the software package.|
 |Paid Developers|Number of paid developers in community over time.|
-|Path to Leadership|A communicated path from lurker to contributor to maintainer. (or. track members: time from user to maintainer/leader). If active contributors are not included in leadership decisions they might lose interest and leave. (Focus on least likely contributor)|
-|Path to Maintainership|Path to maintainership published|
+|Path to Leadership|A communicated path from lurker to contributor to maintainer. (or. track members: time from user to maintainer/leader). If active contributors are not included in leadership decisions they might lose interest and leave. (Focus on least likely contributor).|
+|Path to Maintainership|Path to maintainership published.|
 |Project Life Cycle|Community assigned label. Some communities have a project life cycle for example: proposal, incubaton, active, deprecated, end of life (Source: [Hyperledger](https://wiki.hyperledger.org/community/project-lifecycle)).|
 |Percentile Distribution of First Maintainer Response to Code Merge Request|The proportional frequency of time it takes for a maintainer to make the first response to a code merge request.|
 |Percentile Distribution of First Response Time|The proportional frequency of time it takes for the first response to an issue.|
 |Percentile Distribution of Issue Resolution Time|Proportional frequency of closed issue time duration.|
 |Percentile Distribution of Open Issue Time|Proportional frequency of open issue time duration.|
 |Percentile Distribution of Time to Merge Code|Proportional frequency of code merge to upstream time duration.|
-|[Pull Request Comments](activity-metrics/pull-request-comments.md)|Number of comments per pull request|
-|[Pull Request Discussion Diversity](activity-metrics/pull-request-discussion-diversity.md)|Number of different people discussing each pull request|
-|[Pull Request made/closed](activity-metrics/pull-requests-made-closed.md)|Pull requests made vs. pull requests closed [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap). Encompasses number of pull requests rejected|
-|[Pull Requests Open](activity-metrics/pull-requests-open.md)|Number of open pull requests. Perhaps more telling than total pull requests|
+|[Pull Request Comments](activity-metrics/pull-request-comments.md)|Number of comments per pull request.|
+|[Pull Request Discussion Diversity](activity-metrics/pull-request-discussion-diversity.md)|Number of different people discussing each pull request.|
+|[Pull Request made/closed](activity-metrics/pull-requests-made-closed.md)|Pull requests made vs. pull requests closed [Example](http://repocheck.com/#https%3A%2F%2Fgithub.com%2Ftwbs%2Fbootstrap). Encompasses number of pull requests rejected.|
+|[Pull Requests Open](activity-metrics/pull-requests-open.md)|Number of open pull requests. Perhaps more telling than total pull requests.|
 |Qualified Committers|Contributions over time and what components they commit to over time.|
-|Relative Activity| Sum up the activities (GH issues+comments, GH pull requests+comments and GH commits) for the project members and for the non-project members, then  create a ratio of the two. Compare the activity between committers-as-a-group and contributors-as-a-group. It easily shows when a project is not yet popular, or when a project is not paying attention to its users. I also feel that a balance between the two groups is essential; ie) a project with a lot more contributor than committer activity is one that is failing to recruit committers quickly enough|
-|Release Maturity|Ratio of major and minor releases|
-|Release Note Completeness|Number of functionality changes and bug fixes represented in release notes vs. release. Good for users, also shows diligence of community|
-|Release Velocity|Time between releases. Regular releases are a reliability metric|
-|[Reopened Issues](activity-metrics/reopened-issues.md)|Rate of issues closed but discussion continues or issues that were closed and re-opened|
-|[Repository Size](activity-metrics/repository-size.md)|Overall size of the repository or number of commits|
-|Retrospectives|Existence of after release meetings. Collect lessons learned, improve processes, recognize contributors|
+|Relative Activity| Sum up the activities (GH issues+comments, GH pull requests+comments and GH commits) for the project members and for the non-project members, then  create a ratio of the two. Compare the activity between committers-as-a-group and contributors-as-a-group. It easily shows when a project is not yet popular, or when a project is not paying attention to its users. I also feel that a balance between the two groups is essential; ie) a project with a lot more contributor than committer activity is one that is failing to recruit committers quickly enough.|
+|Release Maturity|Ratio of major and minor releases.|
+|Release Note Completeness|Number of functionality changes and bug fixes represented in release notes vs. release. Good for users, also shows diligence of community.|
+|Release Velocity|Time between releases. Regular releases are a reliability metric.|
+|[Reopened Issues](activity-metrics/reopened-issues.md)|Rate of issues closed but discussion continues or issues that were closed and re-opened.|
+|[Repository Size](activity-metrics/repository-size.md)|Overall size of the repository or number of commits.|
+|Retrospectives|Existence of after release meetings. Collect lessons learned, improve processes, recognize contributors.|
 |Resolution Efficiency|Number of closed issues / number of abandoned issues.|
 |Review Efficiency|Number of merged patches / number of abandoned patches over a set period of time.|
-|Rewards|Rewards, shout-outs, recognition, and mentions in pull-requests or change logs - might improve contribution levels|
-|Roadmap|Existence and quality of roadmap. Best practice as community engagement and scalability (might not be automatically computable)|
-|Role Definitions|Existence and quality of role definitions. Governance related. Relates to "Path to Leadership"|
-|[Size of Code Base](activity-metrics/size-of-code-base.md)|Lines of code|
-|Software Downloads|Number of project software downloads. Beware: downloads might be skewed by builders. Used as measure for success (Grewal, Lilien, & Mallapragada, 2006)|
-|Stack Overflow|Several metrics: # of questions asked, response rate, number of responding people that have verified solutions|
-|Stars|Number of stars (GitHub)|
-|Test Coverage|Percentage of codebase covered by developer tests|
-|Time to Contributor|Time to becoming a contributor|
+|Rewards|Rewards, shout-outs, recognition, and mentions in pull-requests or change logs - might improve contribution levels.|
+|Roadmap|Existence and quality of roadmap. Best practice as community engagement and scalability (might not be automatically computable).|
+|Role Definitions|Existence and quality of role definitions. Governance related. Relates to "Path to Leadership".|
+|[Size of Code Base](activity-metrics/size-of-code-base.md)|Lines of code.|
+|Software Downloads|Number of project software downloads. Beware: downloads might be skewed by builders. Used as measure for success (Grewal, Lilien, & Mallapragada, 2006).|
+|Stack Overflow|Several metrics: # of questions asked, response rate, number of responding people that have verified solutions.|
+|Stars|Number of stars (GitHub).|
+|Test Coverage|Percentage of codebase covered by developer tests.|
+|Time to Contributor|Time to becoming a contributor.|
 |Total Contributing Organizations|The total number of organizations contributing over time.|
 |Total Contributors|The total number of contributors over time on any platform.|
 |Total New Contributing Organizations|The total number of new organizations contributing over time.|
 |Total New Contributors|The total number of new contributors over time on any platform.|
 |Total (Sub-)Projects|The total number of (sub)projects over time.|
-|[Transparency](activity-metrics/transparency.md)|Number of comments per issue. Discussion is occuring openly - could also indicate level of agreement|
-|Unity|Rivalry or unity of community (sentiment analysis)|
-|Update Age|Time since last update|
-|Update Rate|Number of updates over period x|
-|Update Regularity|How consistently and frequently are updates provided|
-|Use of Acronym|Frequency of acronyms used. Specialized language can be a barrier for new contributors|
+|[Transparency](activity-metrics/transparency.md)|Number of comments per issue. Discussion is occuring openly - could also indicate level of agreement.|
+|Unity|Rivalry or unity of community (sentiment analysis).|
+|Update Age|Time since last update.|
+|Update Rate|Number of updates over period x.|
+|Update Regularity|How consistently and frequently are updates provided.|
+|Use of Acronym|Frequency of acronyms used. Specialized language can be a barrier for new contributors.|
 |User Dependency|Number of users who are aware that they depend on the software over time.|
 |User Groups|Number of user groups that perform a variety of crucial marketing, service support, and business-development functions at the grassroots level\\ (Bagozzi & Dholakia, 2006)|
-|[Watchers](activity-metrics/watchers.md)|Number of watchers (GitHub)|
-|YouTube Videos|Number of Youtube videos that mention or specifically deal with the project (e.g. tutorials)
-|V-index|An index of project's first-order and second-order downstream dependencies. For example: if a project has 15 downstream dependencies and those downstream projects have 15 downstream dependencies of their own, the V-index is 15|
+|V-index|An index of project's first-order and second-order downstream dependencies. For example: if a project has 15 downstream dependencies and those downstream projects have 15 downstream dependencies of their own, the V-index is 15.|
+|[Watchers](activity-metrics/watchers.md)|Number of watchers (GitHub).|
+|YouTube Videos|Number of Youtube videos that mention or specifically deal with the project (e.g. tutorials).|
 
 # Additional Thoughts
 The following section are a collection of random thoughts that might be helpful in a future discussion.


### PR DESCRIPTION
We have a long list of all metrics and need to add to it the new metrics that we created in 1_Diversity-Inclusion, 2_Growth-Maturity-Decline, and 3_Risk.

I uniformly _Title Cased_ all metric names and added a period at the end of every description.

Note, that some metrics overlap with existing metrics or are the same with different names. We can clean this up later.